### PR TITLE
Normalize sensor scaling: centralize scales and update displays, tests, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,18 @@ For questions about the project timeline or educational applications, please con
 ---
 
 **Note**: This README will be updated regularly as development progresses. Star this repository to stay informed about release announcements and major milestones.
+
+## Sensor scaling (canonical)
+
+The project uses a canonical set of conversions for motion sensor data to avoid ambiguity across
+examples, tests, and the public API. These constants live in `DroneSystem.SensorScales`.
+
+- Accelerometer raw units: encoded as signed 16-bit integers where
+	raw = m/s^2 * 10. Convert to m/s^2 by multiplying raw * 0.1 (or use
+	`DroneSystem.SensorScales.ACCEL_RAW_TO_MS2`).
+- To convert to G (approx): divide m/s^2 by 9.80665 (or use
+	`DroneSystem.SensorScales.ACCEL_RAW_TO_G`).
+- Angles: raw protocol values are already in degrees — no centi-degree scaling.
+
+Please use the constants above for any conversion rather than hard-coded divisors
+so the behavior stays consistent across the codebase.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,58 @@ tasks.register<JavaExec>("runSmokeTest") {
     // Pass args using: ./gradlew runSmokeTest --args='/dev/cu.usbserial-XXXX'
 }
 
+// ------------------------------------------------------------
+// Run Conservative Flight - gated example (requires --allow-flight)
+// ------------------------------------------------------------
+tasks.register<JavaExec>("runConservativeFlight") {
+    group = "verification"
+    description = "Runs the ConservativeFlight example (requires --allow-flight to actually fly)."
+    classpath = sourceSets.getByName("main").runtimeClasspath
+    mainClass.set("com.otabi.jcodroneedu.examples.ConservativeFlight")
+    // Usage: ./gradlew runConservativeFlight --args='--allow-flight'
+}
+
+// ------------------------------------------------------------
+// Run Test Harness - interactive menu to exercise drone features
+// ------------------------------------------------------------
+tasks.register<JavaExec>("runTestHarness") {
+    group = "verification"
+    description = "Runs the interactive TestHarness example for manual testing."
+    classpath = sourceSets.getByName("main").runtimeClasspath
+    mainClass.set("com.otabi.jcodroneedu.examples.TestHarness")
+    // Forward stdin so Scanner(System.in) in the harness can read user input when run via Gradle
+    standardInput = System.`in`
+}
+
+// -----------------------------------------------------------------
+// Run Sensor Display GUI - Swing-based non-flying telemetry monitor
+// -----------------------------------------------------------------
+tasks.register<JavaExec>("runSensorDisplayGui") {
+    group = "verification"
+    description = "Runs the Swing-based SensorDisplay GUI (non-flying telemetry monitor)."
+    classpath = sourceSets.getByName("main").runtimeClasspath
+    mainClass.set("com.otabi.jcodroneedu.examples.SensorDisplayGui")
+}
+
+// -----------------------------------------------------------------
+// Run AccelTest - simple CLI accelerometer monitor
+// -----------------------------------------------------------------
+tasks.register<JavaExec>("runAccelTest") {
+    group = "verification"
+    description = "Runs the command-line AccelTest (prints accelerometer and angle data)."
+    classpath = sourceSets.getByName("main").runtimeClasspath
+    mainClass.set("com.otabi.jcodroneedu.examples.AccelTest")
+    // Forward stdin so interactive prompts (press Enter) work when run via Gradle
+    standardInput = System.`in`
+}
+
+tasks.register<JavaExec>("runMotionDump") {
+    group = "verification"
+    description = "Dumps raw Motion short values and scaled accel/angle for 5s."
+    classpath = sourceSets.getByName("main").runtimeClasspath
+    mainClass.set("com.otabi.jcodroneedu.examples.MotionDump")
+}
+
 group = "com.otabi"
 version = "1.0-SNAPSHOT"
 

--- a/src/main/java/com/otabi/jcodroneedu/DroneSystem.java
+++ b/src/main/java/com/otabi/jcodroneedu/DroneSystem.java
@@ -1046,6 +1046,21 @@ public class DroneSystem
     }
 
     /**
+     * Sensor scale constants to convert raw sensor integers to SI units.
+     * Keep these centralized to avoid divergent magic numbers across the codebase.
+     */
+    public static class SensorScales {
+        /** Raw accelerometer units: m/s^2 * 10 (i.e. raw / 10.0 -> m/s^2) */
+        public static final double ACCEL_RAW_TO_MS2 = 0.1; // multiply raw by 0.1 to get m/s^2
+
+        /** Raw accelerometer to G units (g) */
+        public static final double ACCEL_RAW_TO_G = ACCEL_RAW_TO_MS2 / 9.80665;
+
+        /** Raw angle units: raw is degrees (no additional scaling) */
+        public static final double ANGLE_RAW_TO_DEG = 1.0; // raw value already in degrees per reference
+    }
+
+    /**
      * Flight control constants for drone operation limits and timing.
      * Centralizes all magic numbers used in flight operations for maintainability and clarity.
      */

--- a/src/main/java/com/otabi/jcodroneedu/FlightController.java
+++ b/src/main/java/com/otabi/jcodroneedu/FlightController.java
@@ -1422,7 +1422,9 @@ public class FlightController {
         Motion motion = drone.getDroneStatus().getMotion();
         if (motion != null) {
             // Convert raw accelerometer data to G-force (typical scale factor)
-            double accelValue = motion.getAccelX() / 1000.0; // Scale factor
+            // Convert raw accel -> G using canonical sensor scale
+            double accelMs2 = motion.getAccelX() * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+            double accelValue = accelMs2 / 9.80665; // G units
             log.debug("X acceleration: {} G", accelValue);
             return accelValue;
         } else {
@@ -1448,7 +1450,8 @@ public class FlightController {
         Motion motion = drone.getDroneStatus().getMotion();
         if (motion != null) {
             // Convert raw accelerometer data to G-force (typical scale factor)
-            double accelValue = motion.getAccelY() / 1000.0; // Scale factor
+            double accelMs2 = motion.getAccelY() * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+            double accelValue = accelMs2 / 9.80665; // G units
             log.debug("Y acceleration: {} G", accelValue);
             return accelValue;
         } else {
@@ -1474,7 +1477,8 @@ public class FlightController {
         Motion motion = drone.getDroneStatus().getMotion();
         if (motion != null) {
             // Convert raw accelerometer data to G-force (typical scale factor)
-            double accelValue = motion.getAccelZ() / 1000.0; // Scale factor
+            double accelMs2 = motion.getAccelZ() * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+            double accelValue = accelMs2 / 9.80665; // G units
             log.debug("Z acceleration: {} G", accelValue);
             return accelValue;
         } else {
@@ -1500,7 +1504,7 @@ public class FlightController {
         Motion motion = drone.getDroneStatus().getMotion();
         if (motion != null) {
             // Convert raw angle data to degrees (typical scale factor)
-            double angleValue = motion.getAngleRoll() / 100.0; // Scale factor
+            double angleValue = motion.getAngleRoll() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG; // degrees
             log.debug("X angle (roll): {} degrees", angleValue);
             return angleValue;
         } else {
@@ -1526,7 +1530,7 @@ public class FlightController {
         Motion motion = drone.getDroneStatus().getMotion();
         if (motion != null) {
             // Convert raw angle data to degrees (typical scale factor)
-            double angleValue = motion.getAnglePitch() / 100.0; // Scale factor
+            double angleValue = motion.getAnglePitch() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG; // degrees
             log.debug("Y angle (pitch): {} degrees", angleValue);
             return angleValue;
         } else {
@@ -1552,7 +1556,7 @@ public class FlightController {
         Motion motion = drone.getDroneStatus().getMotion();
         if (motion != null) {
             // Convert raw angle data to degrees (typical scale factor)
-            double angleValue = motion.getAngleYaw() / 100.0; // Scale factor
+            double angleValue = motion.getAngleYaw() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG; // degrees
             log.debug("Z angle (yaw): {} degrees", angleValue);
             return angleValue;
         } else {
@@ -1566,13 +1570,18 @@ public class FlightController {
     // =============================================================================
 
     /**
-     * Gets accelerometer data as an array.
-     * 
-     * <p>Returns acceleration data for all three axes in a convenient array format.
-     * This is useful for AP CSA students learning about arrays and coordinate systems.</p>
-     * 
-     * @return int array containing [X, Y, Z] acceleration values (scaled from G-force * 1000)
-     * @apiNote Equivalent to Python's various accel methods, returns array for AP CSA compatibility
+    * Gets accelerometer data as an array.
+    * 
+    * <p>Returns the raw accelerometer values from the protocol for all three axes.
+    * The protocol encodes accelerometer samples as signed 16-bit integers where the
+    * raw unit equals m/s^2 * 10 (i.e., multiply raw by {@code DroneSystem.SensorScales.ACCEL_RAW_TO_MS2}
+    * to obtain m/s^2). This method is provided for AP CSA compatibility and educational
+    * examples that expect integer arrays. For human-friendly values, use {@link #getAccelX()},
+    * {@link #getAccelY()}, and {@link #getAccelZ()} which return acceleration in G (approx).
+    * </p>
+    *
+    * @return int array containing [X, Y, Z] raw accelerometer protocol values
+    * @apiNote Equivalent to Python's {@code drone.get_accel()} and returns raw protocol integers
      * @since 1.0
      * @educational This demonstrates array usage and coordinate systems
      */
@@ -1591,7 +1600,11 @@ public class FlightController {
                 motion.getAccelY(), 
                 motion.getAccelZ()
             };
-            log.debug("Acceleration array: [{}, {}, {}]", accelArray[0], accelArray[1], accelArray[2]);
+            // Also log scaled values (m/s^2) for easier debugging
+            double ax_ms2 = accelArray[0] * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+            double ay_ms2 = accelArray[1] * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+            double az_ms2 = accelArray[2] * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+            log.debug("Acceleration array (raw): [{}, {}, {}] -> (m/s^2): [{}, {}, {}]", accelArray[0], accelArray[1], accelArray[2], ax_ms2, ay_ms2, az_ms2);
             return accelArray;
         } else {
             log.warn("Motion data not available for acceleration array reading");

--- a/src/main/java/com/otabi/jcodroneedu/examples/AccelTest.java
+++ b/src/main/java/com/otabi/jcodroneedu/examples/AccelTest.java
@@ -1,0 +1,204 @@
+package com.otabi.jcodroneedu.examples;
+
+import com.otabi.jcodroneedu.Drone;
+import com.otabi.jcodroneedu.DroneNotFoundException;
+import com.otabi.jcodroneedu.DroneSystem;
+import com.otabi.jcodroneedu.protocol.dronestatus.Motion;
+import com.otabi.jcodroneedu.protocol.DataType;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * AccelTest v2 - orchestrated measurement script.
+ * Sequence:
+ *  - 5 s baseline on the ground
+ *  - six user-guided positions (5 s each):
+ *    1) Right side down
+ *    2) Left side down
+ *    3) Front down (nose down)
+ *    4) Back down (tail down)
+ *    5) Top down (upside-down)
+ *    6) Bottom down (upright/top up)
+ * Samples at ~10 Hz. Computes mean and standard deviation for accel X/Y/Z and angle R/P/Y.
+ */
+public class AccelTest {
+    private static final int SAMPLE_RATE_HZ = 10;
+    private static final int SAMPLE_INTERVAL_MS = 1000 / SAMPLE_RATE_HZ;
+
+    private static class Stats {
+        List<Double> ax = new ArrayList<>();
+        List<Double> ay = new ArrayList<>();
+        List<Double> az = new ArrayList<>();
+        List<Double> r = new ArrayList<>();
+        List<Double> p = new ArrayList<>();
+        List<Double> y = new ArrayList<>();
+
+        void add(Motion m) {
+            // Raw accel values are in milli-g (raw units); convert to g then to m/s^2 when printing
+            double rawAx = m.getAccelX();
+            double rawAy = m.getAccelY();
+            double rawAz = m.getAccelZ();
+            // Convert raw accel -> m/s^2 using canonical scale (raw units = m/s^2 * 10)
+            double ax_ms2 = rawAx * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+            double ay_ms2 = rawAy * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+            double az_ms2 = rawAz * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+            // store as G for statistics
+            ax.add(ax_ms2 / 9.80665);
+            ay.add(ay_ms2 / 9.80665);
+            az.add(az_ms2 / 9.80665);
+
+            // Angles are raw degrees per reference (no /100 scaling)
+            r.add((double) m.getAngleRoll() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG);
+            p.add((double) m.getAnglePitch() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG);
+            y.add((double) m.getAngleYaw() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG);
+        }
+
+        static double mean(List<Double> v) {
+            if (v.isEmpty()) return Double.NaN;
+            double s = 0;
+            for (double x : v) s += x;
+            return s / v.size();
+        }
+
+        static double stddev(List<Double> v) {
+            if (v.size() < 2) return Double.NaN;
+            double mu = mean(v);
+            double s = 0;
+            for (double x : v) s += (x - mu) * (x - mu);
+            return Math.sqrt(s / (v.size() - 1));
+        }
+
+        void print(String label) {
+            System.out.printf(Locale.US, "\n=== %s ===\n", label);
+            // Compute means/stddevs in G units, convert to m/s^2 for human-readable output
+            double meanAxG = mean(ax);
+            double meanAyG = mean(ay);
+            double meanAzG = mean(az);
+            double sdAxG = stddev(ax);
+            double sdAyG = stddev(ay);
+            double sdAzG = stddev(az);
+            double meanAx = meanAxG * 9.80665;
+            double meanAy = meanAyG * 9.80665;
+            double meanAz = meanAzG * 9.80665;
+            double sdAx = sdAxG * 9.80665;
+            double sdAy = sdAyG * 9.80665;
+            double sdAz = sdAzG * 9.80665;
+
+            System.out.printf(Locale.US, "Accel X mean=%.3f sd=%.3f m/s^2 (%.3f g)%n", meanAx, sdAx, meanAxG);
+            System.out.printf(Locale.US, "Accel Y mean=%.3f sd=%.3f m/s^2 (%.3f g)%n", meanAy, sdAy, meanAyG);
+            System.out.printf(Locale.US, "Accel Z mean=%.3f sd=%.3f m/s^2 (%.3f g)%n", meanAz, sdAz, meanAzG);
+            System.out.printf(Locale.US, "Angle R mean=%.2f sd=%.2f deg%n", mean(r), stddev(r));
+            System.out.printf(Locale.US, "Angle P mean=%.2f sd=%.2f deg%n", mean(p), stddev(p));
+            System.out.printf(Locale.US, "Angle Y mean=%.2f sd=%.2f deg%n", mean(y), stddev(y));
+
+            // Magnitude check (G)
+            double magG = Math.sqrt(meanAxG * meanAxG + meanAyG * meanAyG + meanAzG * meanAzG);
+            System.out.printf(Locale.US, "Magnitude mean=%.3f g (%.3f m/s^2)%n", magG, magG * 9.80665);
+            if (Double.isFinite(magG) && (magG < 0.5 || magG > 2.0)) {
+                System.out.println("WARNING: magnitude out of expected ~1g range - possible parsing/scale issue or noisy data");
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        System.out.println("AccelTest v2 - guided orientation capture");
+        String port = null;
+        boolean auto = false;
+        if (args != null) {
+            for (String a : args) {
+                if ("--auto".equals(a) || "-a".equals(a)) auto = true;
+                else if (!a.startsWith("--")) port = a;
+            }
+        }
+
+        Drone drone = new Drone();
+        try {
+            try {
+                if (port != null) {
+                    System.out.println("Connecting to port: " + port);
+                    drone.connect(port);
+                } else {
+                    System.out.println("Auto-detecting controller port...");
+                    drone.connect();
+                }
+            } catch (DroneNotFoundException e) {
+                System.err.println("Could not connect to controller: " + e.getMessage());
+                return;
+            }
+
+            BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+
+            // Warm-up baseline capture on the ground for 5 seconds
+            Stats baseline = captureWindow(drone, "Baseline (5s) - drone on the ground, stationary", 5);
+            baseline.print("Baseline");
+
+        String[] positions = new String[]{
+            "Right side down (right face on table)",
+            "Left side down (left face on table)",
+            "Front down (nose down)",
+            "Back down (tail down)",
+            "Top down (upside-down)",
+            "Bottom down (upright)",
+            // Diagonal positions to improve classifier coverage
+            "Front-right down (nose+right)",
+            "Back-right down (tail+right)",
+            "Back-left down (tail+left)"
+        };
+
+            Stats[] results = new Stats[positions.length];
+
+            for (int i = 0; i < positions.length; i++) {
+                System.out.println();
+                System.out.println("Position " + (i + 1) + "/" + positions.length + ": " + positions[i]);
+                System.out.println("Place the drone in this orientation and press Enter to start a 5s capture...");
+                if (!auto) in.readLine();
+                results[i] = captureWindow(drone, "Capture: " + positions[i], 5);
+                results[i].print(positions[i]);
+                System.out.println("Capture complete. Take drone back to neutral and press Enter when ready for next position.");
+                if (!auto) in.readLine();
+            }
+
+            System.out.println("All captures complete. Summary:");
+            for (int i = 0; i < positions.length; i++) {
+                results[i].print("Summary - " + positions[i]);
+            }
+
+        } catch (Exception e) {
+            System.err.println("Unexpected error: " + e.getMessage());
+            e.printStackTrace();
+        } finally {
+            try {
+                if (drone != null) drone.disconnect();
+            } catch (Exception ignore) {
+            }
+            System.out.println("Disconnected.");
+        }
+    }
+
+    private static Stats captureWindow(Drone drone, String label, int seconds) {
+        System.out.println(label + ": capturing for " + seconds + " seconds at ~" + SAMPLE_RATE_HZ + "Hz");
+        Stats s = new Stats();
+        long end = System.currentTimeMillis() + seconds * 1000L;
+        while (System.currentTimeMillis() < end) {
+            try {
+                drone.sendRequest(DataType.Motion);
+                Thread.sleep(80); // give receiver time
+                Motion m = drone.getDroneStatus().getMotion();
+                if (m != null) s.add(m);
+                Thread.sleep(Math.max(1, SAMPLE_INTERVAL_MS - 80));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                System.err.println("Capture error: " + e.getMessage());
+            }
+        }
+        System.out.println("Collected " + s.ax.size() + " samples.");
+        return s;
+    }
+}
+

--- a/src/main/java/com/otabi/jcodroneedu/examples/ConservativeFlight.java
+++ b/src/main/java/com/otabi/jcodroneedu/examples/ConservativeFlight.java
@@ -1,0 +1,60 @@
+package com.otabi.jcodroneedu.examples;
+
+import com.otabi.jcodroneedu.Drone;
+import com.otabi.jcodroneedu.DroneNotFoundException;
+
+/**
+ * Conservative flight example: requires explicit --allow-flight flag to run.
+ * This will perform a short supervised takeoff, hover, and land.
+ */
+public class ConservativeFlight {
+    public static void main(String[] args) {
+        boolean allowFlight = false;
+        for (String a : args) {
+            if ("--allow-flight".equals(a)) allowFlight = true;
+        }
+
+        if (!allowFlight) {
+            System.err.println("Refusing to fly: this example requires --allow-flight flag.");
+            System.err.println("Usage: ./gradlew runConservativeFlight --args='--allow-flight'");
+            System.exit(1);
+        }
+
+        // For CLI usage we'll require the flag and call the helper
+        try (Drone drone = new Drone()) {
+            try {
+                if (!drone.connect()) {
+                    System.err.println("Could not connect to drone. Aborting flight.");
+                    return;
+                }
+            } catch (DroneNotFoundException e) {
+                System.err.println("Connection failed: " + e.getMessage());
+                return;
+            }
+
+            System.out.println("Connected. Preparing conservative flight...");
+            runShortFlight(drone);
+            System.out.println("Flight complete. Disconnecting.");
+        } catch (Exception e) {
+            System.err.println("Error during conservative flight: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Programmatic helper to run a short supervised takeoff/hover/land sequence.
+     * Caller is responsible for ensuring the drone is connected and that this is allowed.
+     */
+    public static void runShortFlight(Drone drone) {
+        if (drone == null) throw new IllegalArgumentException("drone is null");
+        try {
+            // Use conservative timings: quick takeoff, short hover, land
+            drone.takeoff();
+            // hover accepts seconds; keep it short
+            drone.hover(2);
+            drone.land();
+        } catch (Exception e) {
+            throw new RuntimeException("Conservative flight failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/otabi/jcodroneedu/examples/MotionDump.java
+++ b/src/main/java/com/otabi/jcodroneedu/examples/MotionDump.java
@@ -1,0 +1,69 @@
+package com.otabi.jcodroneedu.examples;
+
+import com.otabi.jcodroneedu.Drone;
+import com.otabi.jcodroneedu.DroneNotFoundException;
+import com.otabi.jcodroneedu.DroneSystem;
+import com.otabi.jcodroneedu.protocol.dronestatus.Motion;
+import com.otabi.jcodroneedu.protocol.DataType;
+
+/**
+ * Small diagnostic to dump raw Motion shorts and scaled values.
+ * Usage: ./gradlew runMotionDump
+ */
+public class MotionDump {
+    public static void main(String[] args) {
+        String port = (args != null && args.length > 0) ? args[0] : null;
+        try (Drone drone = new Drone()) {
+            try {
+                if (port != null) drone.connect(port);
+                else drone.connect();
+            } catch (DroneNotFoundException e) {
+                System.err.println("Could not connect: " + e.getMessage());
+                return;
+            }
+
+            System.out.println("Connected. Dumping Motion samples for 5s...");
+            long end = System.currentTimeMillis() + 5000L;
+            while (System.currentTimeMillis() < end) {
+                try {
+                    drone.sendRequest(DataType.Motion);
+                    Thread.sleep(100);
+                    Motion m = drone.getDroneStatus().getMotion();
+                    if (m != null) {
+                        short ax = m.getAccelX();
+                        short ay = m.getAccelY();
+                        short az = m.getAccelZ();
+                        short ar = m.getAngleRoll();
+                        short ap = m.getAnglePitch();
+                        short ayaw = m.getAngleYaw();
+
+                        // Convert accel raw -> m/s^2 using canonical scale (raw units = m/s^2 * 10)
+                        double ax_ms2 = ax * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+                        double ay_ms2 = ay * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+                        double az_ms2 = az * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+                        double roll_deg = ar * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG;
+                        double pitch_deg = ap * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG;
+                        double yaw_deg = ayaw * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG;
+
+                        System.out.printf("RAW ax=%d ay=%d az=%d | a_ms2=%.2f,%.2f,%.2f | angles (deg)=%.2f,%.2f,%.2f\n",
+                                (int) ax, (int) ay, (int) az,
+                                ax_ms2, ay_ms2, az_ms2,
+                                roll_deg, pitch_deg, yaw_deg);
+                    } else {
+                        System.out.println("No motion sample yet");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                } catch (Exception e) {
+                    System.err.println("Error: " + e.getMessage());
+                }
+            }
+
+            drone.disconnect();
+            System.out.println("Done.");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/otabi/jcodroneedu/examples/SensorDisplay.java
+++ b/src/main/java/com/otabi/jcodroneedu/examples/SensorDisplay.java
@@ -1,0 +1,120 @@
+package com.otabi.jcodroneedu.examples;
+
+import com.otabi.jcodroneedu.Drone;
+import com.otabi.jcodroneedu.DroneStatus;
+import com.otabi.jcodroneedu.DroneSystem;
+import com.otabi.jcodroneedu.protocol.linkmanager.Information;
+
+import java.util.Arrays;
+
+/**
+ * Simple non-flying sensor display example modeled after the user's screenshot.
+ * Connects (auto-detect) and prints a snapshot of sensors to stdout then disconnects.
+ */
+public class SensorDisplay {
+    public static void main(String[] args) {
+        try (Drone drone = new Drone()) {
+            try {
+                System.out.println("Auto-detecting and connecting to CoDrone EDU...");
+                boolean ok = drone.pair();
+                if (!ok) {
+                    System.err.println("Could not connect to drone. Exiting.");
+                    return;
+                }
+            } catch (Exception e) {
+                System.err.println("Connection failed: " + e.getMessage());
+                return;
+            }
+
+            System.out.println("Connected. Gathering sensor snapshot...");
+
+            // Information from LinkManager
+            Information info = drone.getLinkManager().getInformation();
+            String model = info != null && info.getModelNumber() != null ? info.getModelNumber().toString() : "UNKNOWN";
+            String fw = info != null && info.getVersion() != null ? info.getVersion().toString() : "UNKNOWN";
+            System.out.printf("Model: %s    Firmware: %s\n", model, fw);
+
+            // DroneStatus snapshot
+            DroneStatus status = drone.getDroneStatus();
+
+            // Battery
+            try {
+                System.out.printf("Battery: %d%%%n", drone.getBattery());
+            } catch (Exception ignored) {
+                System.out.println("Battery: N/A");
+            }
+
+            // Accelerometer / Gyro (use DroneStatus Motion object)
+            System.out.println("--- Motion Sensors ---");
+            try {
+                com.otabi.jcodroneedu.protocol.dronestatus.Motion motion = status.getMotion();
+                if (motion != null) {
+                    double ax_ms2 = motion.getAccelX() * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+                    double ay_ms2 = motion.getAccelY() * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+                    double az_ms2 = motion.getAccelZ() * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+                    double ax_g = ax_ms2 * DroneSystem.SensorScales.ACCEL_RAW_TO_G;
+                    double ay_g = ay_ms2 * DroneSystem.SensorScales.ACCEL_RAW_TO_G;
+                    double az_g = az_ms2 * DroneSystem.SensorScales.ACCEL_RAW_TO_G;
+
+                    System.out.printf("Accelerometer (m/s^2): %.3f  %.3f  %.3f\n", ax_ms2, ay_ms2, az_ms2);
+                    System.out.printf("Accelerometer (g):     %.3f  %.3f  %.3f\n", ax_g, ay_g, az_g);
+                    System.out.printf("Gyro (deg/s):          %d  %d  %d\n", motion.getGyroRoll(), motion.getGyroPitch(), motion.getGyroYaw());
+                    System.out.printf("Angles (deg):          %.1f  %.1f  %.1f\n",
+                            motion.getAngleRoll() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG,
+                            motion.getAnglePitch() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG,
+                            motion.getAngleYaw() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG);
+                } else {
+                    System.out.println("Motion: N/A");
+                }
+            } catch (Exception e) {
+                System.out.println("Motion: N/A");
+            }
+
+            // Ranges
+            System.out.println("--- Ranges (cm) ---");
+            try {
+                System.out.printf("Front: %.1f   Bottom: %.1f\n", status.getRange().getFront(), status.getRange().getBottom());
+            } catch (Exception e) {
+                System.out.println("Ranges: N/A");
+            }
+
+            // Pressure / Temperature
+            System.out.println("--- Environment ---");
+            try {
+                System.out.printf("Pressure: %.3f kPa\n", status.getAltitude().getPressure());
+            } catch (Exception e) {
+                System.out.println("Pressure: N/A");
+            }
+            try {
+                System.out.printf("Temperature: %.2f °C\n", status.getAltitude().getTemperature());
+            } catch (Exception e) {
+                System.out.println("Temperature: N/A");
+            }
+
+            // Colors (front/back)
+            System.out.println("--- Colors ---");
+            try {
+                int[] colors = drone.getColors();
+                System.out.println("Colors (array): " + Arrays.toString(colors));
+            } catch (Exception e) {
+                System.out.println("Colors: N/A");
+            }
+
+            // Position
+            System.out.println("--- Position ---");
+                try {
+                // position values are returned in millimeters by the protocol — convert to centimeters for display
+                System.out.printf("X: %.2f cm   Y: %.2f cm   Z: %.2f cm\n",
+                        status.getPosition().getX() / 10.0, status.getPosition().getY() / 10.0, status.getPosition().getZ() / 10.0);
+            } catch (Exception e) {
+                System.out.println("Position: N/A");
+            }
+
+            System.out.println("--- End of snapshot. Disconnecting.");
+
+        } catch (Exception e) {
+            System.err.println("Unhandled error: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/otabi/jcodroneedu/examples/SensorDisplayGui.java
+++ b/src/main/java/com/otabi/jcodroneedu/examples/SensorDisplayGui.java
@@ -1,0 +1,361 @@
+package com.otabi.jcodroneedu.examples;
+
+import com.otabi.jcodroneedu.Drone;
+import com.otabi.jcodroneedu.DroneSystem;
+import com.otabi.jcodroneedu.DroneStatus;
+import com.otabi.jcodroneedu.protocol.cardreader.CardColor;
+import com.otabi.jcodroneedu.protocol.dronestatus.*;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Simple Swing-based sensor display. Connects to the controller, polls non-flying
+ * telemetry and displays it in a lightweight GUI. Safe by default (no flight commands).
+ */
+public class SensorDisplayGui {
+
+    private final JFrame frame = new JFrame("CoDrone EDU Sensor Monitor");
+    private final JLabel batteryLabel = new JLabel("N/A", SwingConstants.CENTER);
+    private final JLabel accelLabel = new JLabel("N/A", SwingConstants.CENTER);
+    private final JLabel gyroLabel = new JLabel("N/A", SwingConstants.CENTER);
+    private final JLabel angleLabel = new JLabel("N/A", SwingConstants.CENTER);
+    private final JProgressBar rollBar = new JProgressBar(-180, 180);
+    private final JProgressBar pitchBar = new JProgressBar(-180, 180);
+    private final ArrowComponent headingArrow = new ArrowComponent();
+    private final JProgressBar leftRange = new JProgressBar(0, 500); // mm
+    private final JProgressBar frontRange = new JProgressBar(0, 500);
+    private final JProgressBar rightRange = new JProgressBar(0, 500);
+    private final JProgressBar rearRange = new JProgressBar(0, 500);
+    private final JProgressBar topRange = new JProgressBar(0, 500);
+    private final JProgressBar bottomRange = new JProgressBar(0, 500);
+    private final JLabel altitudeLabel = new JLabel("N/A", SwingConstants.CENTER);
+    private final JLabel positionLabel = new JLabel("N/A", SwingConstants.CENTER);
+    private final JPanel colorSwatch = new JPanel();
+
+    private Drone drone;
+    private ScheduledExecutorService executor;
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            SensorDisplayGui gui = new SensorDisplayGui();
+            gui.start();
+        });
+    }
+
+    public void start() {
+        setupUi();
+
+        // Connect to drone in background so UI stays responsive
+        Executors.newSingleThreadExecutor().execute(() -> {
+            try {
+                drone = new Drone();
+                boolean ok;
+                if (getArgPort() != null) {
+                    ok = drone.connect(getArgPort());
+                } else {
+                    ok = drone.connect();
+                }
+
+                if (!ok) {
+                    showError("Could not connect to CoDrone EDU controller. Ensure it is powered and paired.");
+                    return;
+                }
+
+                // Start periodic polling at 5 Hz
+                executor = Executors.newSingleThreadScheduledExecutor();
+                executor.scheduleAtFixedRate(this::pollAndUpdate, 0, 200, TimeUnit.MILLISECONDS);
+
+            } catch (Exception e) {
+                showError("Connection failed: " + e.getMessage());
+            }
+        });
+    }
+
+    private String getArgPort() {
+        // Gradle JavaExec will not make args accessible here easily; keep null by default
+        return null;
+    }
+
+    private void showError(String msg) {
+        SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(frame, msg, "Error", JOptionPane.ERROR_MESSAGE));
+    }
+
+    private void setupUi() {
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        frame.setLayout(new BorderLayout());
+
+    JPanel center = new JPanel(new GridBagLayout());
+    GridBagConstraints c = new GridBagConstraints();
+    c.fill = GridBagConstraints.BOTH;
+    c.insets = new Insets(6, 6, 6, 6);
+
+    // Top row: Battery and Color
+    c.gridx = 0; c.gridy = 0; c.weightx = 0.6; c.weighty = 0.0;
+    center.add(wrapWithTitledPanel("Battery", batteryLabel, 24f), c);
+
+    c.gridx = 1; c.gridy = 0; c.weightx = 0.4;
+    colorSwatch.setPreferredSize(new Dimension(120, 60));
+    colorSwatch.setBorder(BorderFactory.createLineBorder(Color.DARK_GRAY));
+    center.add(wrapWithTitledPanel("Card Color", (JComponent) colorSwatch), c);
+
+    // Middle row: Motion and Angles
+    c.gridx = 0; c.gridy = 1; c.gridwidth = 2; c.weighty = 0.0;
+    JPanel motionPanel = new JPanel(new GridLayout(1, 3));
+    motionPanel.add(wrapWithTitledPanel("Accel (m/s^2, g)", accelLabel, 14f));
+    motionPanel.add(wrapWithTitledPanel("Gyro (deg/s)", gyroLabel, 14f));
+    motionPanel.add(wrapWithTitledPanel("Angle (deg)", angleLabel, 14f));
+    center.add(motionPanel, c);
+
+    // Attitude visualization: roll/pitch bars and heading arrow
+    c.gridx = 0; c.gridy = 2; c.gridwidth = 2; c.weighty = 0.0;
+    JPanel attitudePanel = new JPanel(new GridLayout(1, 3, 6, 6));
+    rollBar.setStringPainted(true);
+    pitchBar.setStringPainted(true);
+    attitudePanel.add(wrapWithTitledPanel("Roll (deg)", rollBar));
+    attitudePanel.add(wrapWithTitledPanel("Heading", headingArrow));
+    attitudePanel.add(wrapWithTitledPanel("Pitch (deg)", pitchBar));
+    center.add(attitudePanel, c);
+
+    // Range sensors grid
+    c.gridx = 0; c.gridy = 3; c.gridwidth = 2; c.weighty = 0.0;
+    JPanel ranges = new JPanel(new GridLayout(3, 2, 6, 6));
+    ranges.add(wrapWithTitledPanel("Left (mm)", leftRange));
+    ranges.add(wrapWithTitledPanel("Front (mm)", frontRange));
+    ranges.add(wrapWithTitledPanel("Right (mm)", rightRange));
+    ranges.add(wrapWithTitledPanel("Rear (mm)", rearRange));
+    ranges.add(wrapWithTitledPanel("Top (mm)", topRange));
+    ranges.add(wrapWithTitledPanel("Bottom (mm)", bottomRange));
+    center.add(ranges, c);
+
+    // Bottom row: Altitude and Position
+    c.gridx = 0; c.gridy = 3; c.gridwidth = 2; c.weighty = 0.0;
+    JPanel bottom = new JPanel(new GridLayout(1, 2));
+    bottom.add(wrapWithTitledPanel("Altitude / Pressure / Temp", altitudeLabel, 12f));
+    bottom.add(wrapWithTitledPanel("Position (m)", positionLabel, 12f));
+    center.add(bottom, c);
+
+    frame.add(center, BorderLayout.CENTER);
+
+    frame.setSize(800, 600);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+
+        frame.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                shutdown();
+            }
+        });
+    }
+
+    private void pollAndUpdate() {
+        if (drone == null || !drone.isConnected()) return;
+
+        try {
+            // Request recent data non-destructively
+            drone.sendRequest(com.otabi.jcodroneedu.protocol.DataType.Motion);
+            drone.sendRequest(com.otabi.jcodroneedu.protocol.DataType.Altitude);
+            drone.sendRequest(com.otabi.jcodroneedu.protocol.DataType.Range);
+            drone.sendRequest(com.otabi.jcodroneedu.protocol.DataType.Position);
+            drone.sendRequest(com.otabi.jcodroneedu.protocol.DataType.State);
+            drone.sendRequest(com.otabi.jcodroneedu.protocol.DataType.CardColor);
+
+            // Allow a short window for receiver thread to populate status
+            Thread.sleep(30);
+
+            DroneStatus status = drone.getDroneStatus();
+
+            // Battery from state
+            com.otabi.jcodroneedu.protocol.dronestatus.State state = status.getState();
+            final String batteryText = state != null ? String.format("Battery: %d%%", state.getBattery()) : "Battery: N/A";
+
+            // Motion
+            Motion motion = status.getMotion();
+            final String accelText;
+            final String gyroText = motion != null ? String.format("Gyro: %.1f, %.1f, %.1f", (double)motion.getGyroRoll(), (double)motion.getGyroPitch(), (double)motion.getGyroYaw()) : "Gyro: N/A";
+            final String angleText;
+            if (motion != null) {
+                double ax_ms2 = motion.getAccelX() * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+                double ay_ms2 = motion.getAccelY() * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+                double az_ms2 = motion.getAccelZ() * DroneSystem.SensorScales.ACCEL_RAW_TO_MS2;
+                double ax_g = ax_ms2 / 9.80665;
+                double ay_g = ay_ms2 / 9.80665;
+                double az_g = az_ms2 / 9.80665;
+                accelText = String.format("m/s^2: %.2f, %.2f, %.2f | g: %.3f, %.3f, %.3f", ax_ms2, ay_ms2, az_ms2, ax_g, ay_g, az_g);
+                angleText = String.format("Angle: %.1f, %.1f, %.1f", motion.getAngleRoll() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG, motion.getAnglePitch() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG, motion.getAngleYaw() * DroneSystem.SensorScales.ANGLE_RAW_TO_DEG);
+            } else {
+                accelText = "Accel: N/A";
+                angleText = "Angle: N/A";
+            }
+
+            // Range
+            Range range = status.getRange();
+
+            // Altitude
+            Altitude alt = status.getAltitude();
+            final String altText = alt != null ? String.format("Alt: %.2fm Pressure: %.2fhPa Temp: %.2f°C RangeHeight: %.2fcm", alt.getAltitude(), alt.getPressure(), alt.getTemperature(), alt.getRangeHeight()) : "Altitude: N/A";
+
+            // Position
+            Position pos = status.getPosition();
+            final String posText = pos != null ? String.format("X: %.2fm  Y: %.2fm  Z: %.2fm", pos.getX() / 1000.0, pos.getY() / 1000.0, pos.getZ() / 1000.0) : "Position: N/A";
+
+            // Card color
+            CardColor cardColor = status.getCardColor();
+
+            SwingUtilities.invokeLater(() -> {
+                // compact labels
+                batteryLabel.setText(batteryText.replace("Battery: ", ""));
+                accelLabel.setText(accelText);
+                gyroLabel.setText(gyroText.replace("Gyro: ", ""));
+                angleLabel.setText(angleText.replace("Angle: ", ""));
+
+                // Update range progress bars (values are in mm)
+                if (range != null) {
+                    leftRange.setValue(range.getLeft()); leftRange.setString(String.format("%d mm", range.getLeft()));
+                    frontRange.setValue(range.getFront()); frontRange.setString(String.format("%d mm", range.getFront()));
+                    rightRange.setValue(range.getRight()); rightRange.setString(String.format("%d mm", range.getRight()));
+                    rearRange.setValue(range.getRear()); rearRange.setString(String.format("%d mm", range.getRear()));
+                    topRange.setValue(range.getTop()); topRange.setString(String.format("%d mm", range.getTop()));
+                    bottomRange.setValue(range.getBottom()); bottomRange.setString(String.format("%d mm", range.getBottom()));
+                }
+
+                // Update roll/pitch/heading visual widgets
+                if (motion != null) {
+                    int roll = motion.getAngleRoll();
+                    int pitch = motion.getAnglePitch();
+                    int yaw = motion.getAngleYaw();
+                    rollBar.setValue(roll);
+                    rollBar.setString(String.format("%d°", roll));
+                    pitchBar.setValue(pitch);
+                    pitchBar.setString(String.format("%d°", pitch));
+                    headingArrow.setHeading(yaw);
+                }
+
+                altitudeLabel.setText(altText);
+                positionLabel.setText(posText);
+
+                // Color swatch
+                if (cardColor != null) {
+                    colorSwatch.setBackground(parseCardColor(cardColor));
+                } else {
+                    colorSwatch.setBackground(Color.LIGHT_GRAY);
+                }
+            });
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            // Silence errors so GUI doesn't spam dialogs
+            // But if drone disconnected, show in status
+            SwingUtilities.invokeLater(() -> batteryLabel.setText("Battery: ERROR"));
+        }
+    }
+
+    private void shutdown() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+        if (drone != null) {
+            try {
+                drone.disconnect();
+            } catch (Exception ignore) {
+            }
+        }
+        System.exit(0);
+    }
+
+    // --- UI helpers ---
+    private JPanel wrapWithTitledPanel(String title, JComponent comp) {
+        JPanel p = new JPanel(new BorderLayout());
+        p.add(comp, BorderLayout.CENTER);
+        p.setBorder(BorderFactory.createTitledBorder(title));
+        return p;
+    }
+
+    private JPanel wrapWithTitledPanel(String title, JLabel label, float bigFontSize) {
+        if (bigFontSize > 0) {
+            label.setFont(label.getFont().deriveFont(Font.BOLD, bigFontSize));
+        }
+        return wrapWithTitledPanel(title, (JComponent) label);
+    }
+
+    private JPanel wrapWithTitledPanel(String title, JProgressBar bar) {
+        bar.setStringPainted(true);
+        return wrapWithTitledPanel(title, (JComponent) bar);
+    }
+
+    private Color parseCardColor(CardColor cardColor) {
+        String s = cardColor.toString().toLowerCase();
+        switch (s) {
+            case "red": return Color.RED;
+            case "green": return Color.GREEN;
+            case "blue": return Color.BLUE;
+            case "yellow": return Color.YELLOW;
+            case "purple": return new Color(128, 0, 128);
+            case "white": return Color.WHITE;
+            case "black": return Color.BLACK;
+            default: return Color.GRAY;
+        }
+    }
+
+    // Simple arrow component to indicate yaw/heading
+    private static class ArrowComponent extends JComponent {
+        private volatile int heading = 0; // degrees
+
+        public ArrowComponent() {
+            setPreferredSize(new Dimension(120, 120));
+        }
+
+        public void setHeading(int degrees) {
+            this.heading = degrees;
+            repaint();
+        }
+
+        @Override
+        protected void paintComponent(Graphics g) {
+            super.paintComponent(g);
+            Graphics2D g2 = (Graphics2D) g.create();
+            try {
+                int w = getWidth();
+                int h = getHeight();
+                int cx = w / 2;
+                int cy = h / 2;
+
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                g2.setColor(Color.WHITE);
+                g2.fillRect(0, 0, w, h);
+
+                // Draw circle background
+                g2.setColor(Color.LIGHT_GRAY);
+                int r = Math.min(w, h) / 2 - 8;
+                g2.fillOval(cx - r, cy - r, r * 2, r * 2);
+
+                // Rotate and draw arrow
+                g2.setColor(Color.RED);
+                g2.translate(cx, cy);
+                g2.rotate(Math.toRadians(-heading)); // negative so positive yaw is clockwise visually
+
+                int arrowLen = r - 16;
+                Polygon arrow = new Polygon();
+                arrow.addPoint(0, -arrowLen);
+                arrow.addPoint(6, -arrowLen + 18);
+                arrow.addPoint(2, -arrowLen + 18);
+                arrow.addPoint(2, arrowLen - 12);
+                arrow.addPoint(-2, arrowLen - 12);
+                arrow.addPoint(-2, -arrowLen + 18);
+                arrow.addPoint(-6, -arrowLen + 18);
+
+                g2.fill(arrow);
+
+            } finally {
+                g2.dispose();
+            }
+        }
+    }
+}

--- a/src/main/java/com/otabi/jcodroneedu/examples/TestHarness.java
+++ b/src/main/java/com/otabi/jcodroneedu/examples/TestHarness.java
@@ -1,0 +1,197 @@
+package com.otabi.jcodroneedu.examples;
+
+import com.otabi.jcodroneedu.Drone;
+// DroneNotFoundException not used; handle generic exceptions instead
+
+import java.util.Scanner;
+
+/**
+ * Interactive menu-driven test harness for exercising flight and sensor code.
+ * - safe-by-default: flight commands require explicit confirmation
+ * - reuses Drone.connect/pair APIs from the project
+ */
+public class TestHarness {
+
+    private static void printMenu() {
+        System.out.println("--- CoDrone EDU Test Harness ---");
+        System.out.println("1) Auto-detect & connect");
+        System.out.println("2) Connect to specific port");
+        System.out.println("3) Show battery");
+        System.out.println("4) Show model/info");
+        System.out.println("5) Read sensors once (state/joystick)");
+        System.out.println("6) Hover (safe) — will run a short hover");
+        System.out.println("7) Conservative flight (requires explicit confirm)");
+        System.out.println("8) Disconnect");
+        System.out.println("9) Quit");
+        System.out.print("Select> ");
+    }
+
+    public static void main(String[] args) {
+        Scanner in = new Scanner(System.in);
+        Drone drone = null;
+
+        try {
+            while (true) {
+                printMenu();
+                String line = in.nextLine().trim();
+                if (line.isEmpty()) continue;
+
+                int choice;
+                try {
+                    choice = Integer.parseInt(line);
+                } catch (NumberFormatException nfe) {
+                    System.out.println("Invalid selection");
+                    continue;
+                }
+
+                switch (choice) {
+                    case 1:
+                        if (drone != null && drone.isConnected()) {
+                            System.out.println("Already connected.");
+                            break;
+                        }
+                        try {
+                            drone = new Drone();
+                            System.out.println("Attempting auto-detect and pair()...");
+                            boolean ok = drone.pair();
+                            System.out.println("Connected: " + ok);
+                        } catch (Exception e) {
+                            System.err.println("Drone not found or connection failed: " + e.getMessage());
+                        }
+                        break;
+
+                    case 2:
+                        System.out.print("Port path: ");
+                        String port = in.nextLine().trim();
+                        if (port.isEmpty()) {
+                            System.out.println("No port provided.");
+                            break;
+                        }
+                        if (drone == null) drone = new Drone();
+                        boolean ok = drone.connect(port);
+                        System.out.println("Connected: " + ok);
+                        break;
+
+                    case 3:
+                        if (drone == null || !drone.isConnected()) {
+                            System.out.println("Not connected");
+                            break;
+                        }
+                        try {
+                            System.out.printf("Battery: %d%%%n", drone.getBattery());
+                        } catch (Exception e) {
+                            System.out.println("Error reading battery: " + e.getMessage());
+                        }
+                        break;
+
+                    case 4:
+                        if (drone == null || !drone.isConnected()) {
+                            System.out.println("Not connected");
+                            break;
+                        }
+                        try {
+                            // Use existing LinkManager / Information API
+                            com.otabi.jcodroneedu.LinkManager lm = drone.getLinkManager();
+                            if (lm != null && lm.getInformation() != null) {
+                                com.otabi.jcodroneedu.protocol.linkmanager.Information info = lm.getInformation();
+                                String model = info.getModelNumber() != null ? info.getModelNumber().toString() : "UNKNOWN";
+                                String fw = info.getVersion() != null ? info.getVersion().toString() : "UNKNOWN";
+                                System.out.println("Model: " + model);
+                                System.out.println("Firmware: " + fw);
+                            } else {
+                                System.out.println("Model/firmware information not available yet.");
+                            }
+                        } catch (Exception e) {
+                            System.out.println("Error reading information: " + e.getMessage());
+                        }
+                        break;
+
+                    case 5:
+                        if (drone == null || !drone.isConnected()) {
+                            System.out.println("Not connected");
+                            break;
+                        }
+                        try {
+                            // Drone exposes a DroneStatus and joystick data via existing APIs
+                            System.out.println("Status: " + drone.getDroneStatus());
+                            System.out.println("Joystick: " + java.util.Arrays.toString(drone.getJoystickData()));
+                        } catch (Exception e) {
+                            System.out.println("Error reading sensors: " + e.getMessage());
+                        }
+                        break;
+
+                    case 6:
+                        if (drone == null || !drone.isConnected()) {
+                            System.out.println("Not connected");
+                            break;
+                        }
+                        System.out.println("This will send a safe hover command (no takeoff). Confirm (y/N)? ");
+                        String confirm = in.nextLine().trim();
+                        if (confirm.equalsIgnoreCase("y")) {
+                            try {
+                                drone.hover(0.5);
+                                System.out.println("Hover command sent.");
+                            } catch (Exception e) {
+                                System.out.println("Hover failed: " + e.getMessage());
+                            }
+                        } else {
+                            System.out.println("Aborted.");
+                        }
+                        break;
+
+                    case 7:
+                        if (drone == null || !drone.isConnected()) {
+                            System.out.println("Not connected");
+                            break;
+                        }
+                        System.out.println("Conservative flight will perform a short supervised takeoff/hover/land sequence.");
+                        System.out.println("Type CONFIRM to proceed: ");
+                        String proceed = in.nextLine().trim();
+                        if (proceed.equals("CONFIRM")) {
+                            System.out.println("Proceeding with conservative flight...");
+                            try {
+                                // Reuse conservative pattern from examples
+                                com.otabi.jcodroneedu.examples.ConservativeFlight.runShortFlight(drone);
+                                System.out.println("Conservative flight completed.");
+                            } catch (Exception e) {
+                                System.out.println("Flight failed: " + e.getMessage());
+                            }
+                        } else {
+                            System.out.println("Conservative flight aborted.");
+                        }
+                        break;
+
+                    case 8:
+                        if (drone != null) {
+                            try {
+                                drone.disconnect();
+                                System.out.println("Disconnected.");
+                            } catch (Exception e) {
+                                System.out.println("Disconnect failed: " + e.getMessage());
+                            }
+                        } else {
+                            System.out.println("Not connected");
+                        }
+                        break;
+
+                    case 9:
+                        System.out.println("Quitting... Goodbye.");
+                        if (drone != null) {
+                            try { drone.disconnect(); } catch (Exception ignored) {}
+                        }
+                        in.close();
+                        return;
+
+                    default:
+                        System.out.println("Unknown option");
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                if (drone != null) drone.disconnect();
+            } catch (Exception ignored) {}
+        }
+    }
+}

--- a/src/main/java/com/otabi/jcodroneedu/receiver/Receiver.java
+++ b/src/main/java/com/otabi/jcodroneedu/receiver/Receiver.java
@@ -3,6 +3,8 @@ package com.otabi.jcodroneedu.receiver;
 import com.otabi.jcodroneedu.*;
 import com.otabi.jcodroneedu.protocol.*;
 import com.otabi.jcodroneedu.protocol.dronestatus.Attitude;
+import com.otabi.jcodroneedu.protocol.dronestatus.Motion;
+import com.otabi.jcodroneedu.protocol.dronestatus.Range;
 import com.otabi.jcodroneedu.protocol.dronestatus.Altitude;
 import com.otabi.jcodroneedu.protocol.dronestatus.Position;
 import com.otabi.jcodroneedu.protocol.dronestatus.State;
@@ -14,6 +16,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -38,6 +41,9 @@ public class Receiver {
     // --- Acknowledgment Handling ---
     private final Map<DataType, CompletableFuture<Void>> pendingAcks = new ConcurrentHashMap<>();
     private final Map<DataType, Consumer<Serializable>> handlers = new HashMap<>();
+    // Simple rate-limiting for repeated debug messages
+    private DataType lastLoggedDataType = null;
+    private long lastLoggedTimeMs = 0;
 
     // --- State machine fields ---
     private Section currentSection;
@@ -68,6 +74,8 @@ public class Receiver {
         handlers.put(DataType.Attitude, msg -> droneStatus.setAttitude((Attitude) msg));
         handlers.put(DataType.Position, msg -> droneStatus.setPosition((Position) msg));
         handlers.put(DataType.Altitude, msg -> droneStatus.setAltitude((Altitude) msg));
+    handlers.put(DataType.Motion, msg -> droneStatus.setMotion((Motion) msg));
+    handlers.put(DataType.Range, msg -> droneStatus.setRange((Range) msg));
         handlers.put(DataType.CardColor, msg -> droneStatus.setCardColor((CardColor) msg));
         handlers.put(DataType.Trim, msg -> droneStatus.setTrim((com.otabi.jcodroneedu.protocol.settings.Trim) msg));
         handlers.put(DataType.RawFlow, msg -> droneStatus.setRawFlow((RawFlow) msg));
@@ -134,7 +142,7 @@ public class Receiver {
                 currentSection = Section.HEADER; // Transition to next section
                 index = 0;
             } else {
-                log.warn("Invalid start sequence. Expected 0x55, got 0x{:02X}", data);
+                log.warn("Invalid start sequence. Expected 0x55, got 0x{}", String.format("%02X", data & 0xFF));
                 return false;
             }
         }
@@ -148,7 +156,9 @@ public class Receiver {
                 header.setDataType(DataType.fromByte(data));
                 if (header.getDataType() == null) throw new IllegalArgumentException("DataType is null");
             } catch (Exception e) {
-                log.error("Invalid DataType received: 0x{:02X}", data, e);
+                // Log a concise warning with the raw byte in hex, avoid stack-trace spam from unexpected bytes
+                String hex = String.format("%02X", data & DroneSystem.CommunicationConstants.BYTE_MASK);
+                log.debug("Invalid DataType received: 0x{}", hex);
                 return false;
             }
         } else if (index == 1) {
@@ -161,14 +171,14 @@ public class Receiver {
             try {
                 header.setFrom(DeviceType.fromByte(data));
             } catch (Exception e) {
-                log.error("Invalid 'From' DeviceType received: 0x{:02X}", data, e);
+                log.error("Invalid 'From' DeviceType received: 0x{}", String.format("%02X", data & 0xFF), e);
                 return false;
             }
         } else if (index == 3) {
             try {
                 header.setTo(DeviceType.fromByte(data));
             } catch (Exception e) {
-                log.error("Invalid 'To' DeviceType received: 0x{:02X}", data, e);
+                log.error("Invalid 'To' DeviceType received: 0x{}", String.format("%02X", data & 0xFF), e);
                 return false;
             }
 
@@ -202,12 +212,22 @@ public class Receiver {
             crc16received |= (data & DroneSystem.CommunicationConstants.BYTE_MASK) << 8;
 
             if (crc16received == crc16calculated) {
-                log.info("CRC OK for {}. Received: 0x{:04X}", header.getDataType(), crc16received);
+                // Avoid spamming the log for high-frequency telemetry (e.g., Joystick)
+                long now = System.currentTimeMillis();
+                DataType dt = header.getDataType();
+                if (dt != lastLoggedDataType || (now - lastLoggedTimeMs) > 250) {
+                    String hex = String.format("%04X", crc16received & 0xFFFF);
+                    log.debug("CRC OK for {} (0x{}).", dt, hex);
+                    lastLoggedDataType = dt;
+                    lastLoggedTimeMs = now;
+                }
                 processPayload();
                 reset();
             } else {
-                log.error("CRC Mismatch for {}. Received: 0x{:04X}, Calculated: 0x{:04X}",
-                        header.getDataType(), crc16received, crc16calculated);
+                String rhex = String.format("%04X", crc16received & 0xFFFF);
+                String chex = String.format("%04X", crc16calculated & 0xFFFF);
+                log.error("CRC Mismatch for {}. Received: 0x{}, Calculated: 0x{}",
+                        header.getDataType(), rhex, chex);
                 return false;
             }
         }
@@ -220,8 +240,11 @@ public class Receiver {
      * map to dispatch it to the correct processor.
      */
     private void processPayload() {
-        dataBuffer.flip(); // Prepare buffer for reading
-        ByteBuffer payloadBuffer = dataBuffer;
+    dataBuffer.flip(); // Prepare buffer for reading
+    ByteBuffer payloadBuffer = dataBuffer;
+    // The controller sends multi-byte fields in little-endian order. Ensure
+    // we interpret the incoming payload as little-endian before parsing.
+    payloadBuffer.order(ByteOrder.LITTLE_ENDIAN);
 
         try {
             // Handle Ack separately as it doesn't create a new object to store.
@@ -241,6 +264,30 @@ public class Receiver {
             }
 
             // Tell the message to parse itself from the payload.
+            // Diagnostic: if this is a Motion payload, log the raw payload bytes and a little-endian
+            // interpretation of the shorts so we can verify endianness/scale without altering parsing.
+            if (header.getDataType() == com.otabi.jcodroneedu.protocol.DataType.Motion) {
+                try {
+                    ByteBuffer dup = payloadBuffer.duplicate();
+                    dup.order(ByteOrder.BIG_ENDIAN); // original buffer default
+                    byte[] arr = new byte[dup.remaining()];
+                    dup.get(arr);
+                    StringBuilder sb = new StringBuilder();
+                    for (byte b : arr) sb.append(String.format("%02X ", b));
+                    log.info("Motion payload bytes (len={}): {}", arr.length, sb.toString());
+
+                    // Interpret as little-endian signed shorts for quick human-readable check
+                    ByteBuffer peek = ByteBuffer.wrap(arr).order(ByteOrder.LITTLE_ENDIAN);
+                    StringBuilder vals = new StringBuilder();
+                    for (int i = 0; i < 9 && peek.remaining() >= 2; i++) {
+                        short v = peek.getShort();
+                        vals.append(String.format("%d%s", (int) v, (i < 8 ? "," : "")));
+                    }
+                    log.info("Motion payload as little-endian shorts: {}", vals.toString());
+                } catch (Exception e) {
+                    log.warn("Failed to dump Motion payload bytes: {}", e.getMessage());
+                }
+            }
             message.parse(payloadBuffer);
 
             // Look up the correct handler function and execute it.
@@ -266,7 +313,8 @@ public class Receiver {
     public void onAckReceived(DataType ackType) {
         // Defensive: ackType may be null if the incoming byte did not map to a known DataType
         if (ackType == null) {
-            log.warn("Received an ACK for an unknown/invalid DataType (null). Ignoring.");
+            // Lowered to debug: we often receive unknown/invalid ACK bytes when controller is chatty.
+            log.debug("Received an ACK for an unknown/invalid DataType (null). Ignoring.");
             return;
         }
 
@@ -275,7 +323,8 @@ public class Receiver {
             future.complete(null);
             log.info("ACK received and processed for {}", ackType);
         } else {
-            log.warn("Received an unexpected ACK for {}", ackType);
+            // Unexpected ACKs are common for unsolicited status updates — log at debug to avoid spam.
+            log.debug("Received an unexpected ACK for {}", ackType);
         }
     }
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    You can override the receiver logger level at runtime using a system property:
+        ./gradlew runTestHarness -Dorg.gradle.jvmargs="-Djcodrone.logging.receiver=DEBUG"
+    or when running the jar directly:
+        java -Djcodrone.logging.receiver=DEBUG -jar build/libs/JCoDroneEdu-1.0-SNAPSHOT.jar
+
+    The property defaults to INFO to avoid noisy telemetry logs; set to DEBUG when you need packet-level details.
+-->
 <Configuration status="WARN">
+        <Properties>
+                <!-- default level for the receiver logger; can be overridden with -Djcodrone.logging.receiver -->
+                <Property name="jcodrone.logging.receiver">INFO</Property>
+        </Properties>
     <Appenders>
         <!-- Console Appender for development -->
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
-        
-        <!-- File Appender for detailed logging -->
-        <File name="FileAppender" fileName="logs/codrone-edu.log">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
-        </File>
         
         <!-- Rolling File Appender for production -->
         <RollingFile name="RollingFileAppender" fileName="logs/codrone-edu.log" 
@@ -55,8 +62,8 @@
             <AppenderRef ref="RollingFileAppender"/>
         </Logger>
         
-        <!-- Receiver - can be noisy, so INFO level by default -->
-        <Logger name="com.otabi.jcodroneedu.receiver" level="INFO" additivity="false">
+        <!-- Receiver - can be noisy. Uses a runtime-settable property to control level -->
+        <Logger name="com.otabi.jcodroneedu.receiver" level="${jcodrone.logging.receiver}" additivity="false">
             <AppenderRef ref="Console"/>
             <AppenderRef ref="RollingFileAppender"/>
         </Logger>

--- a/src/test/java/com/otabi/jcodroneedu/SensorDataAccessTest.java
+++ b/src/test/java/com/otabi/jcodroneedu/SensorDataAccessTest.java
@@ -268,13 +268,14 @@ public class SensorDataAccessTest {
         void testGetAccelX() {
             // Arrange
             when(mockStatus.getMotion()).thenReturn(mockMotion);
-            when(mockMotion.getAccelX()).thenReturn((short) 1500); // Raw value
+            // raw units: m/s^2 * 10 -> to get 1.5 G, raw ~= 1.5 * 9.80665 / 0.1 = ~147
+            when(mockMotion.getAccelX()).thenReturn((short) 147); // Raw value corresponding to 1.5 G
 
             // Act
             double accelX = flightController.getAccelX();
 
             // Assert
-            assertEquals(1.5, accelX, 0.01, "Acceleration should be scaled to G-force");
+            assertEquals(1.5, accelX, 0.02, "Acceleration should be scaled to G-force");
             verify(mockDrone).sendRequest(DataType.Motion);
         }
 
@@ -283,13 +284,14 @@ public class SensorDataAccessTest {
         void testGetAccelY() {
             // Arrange
             when(mockStatus.getMotion()).thenReturn(mockMotion);
-            when(mockMotion.getAccelY()).thenReturn((short) -800); // Negative raw value
+            // raw for -0.8 G -> ~ -0.8 * 9.80665 / 0.1 = -78
+            when(mockMotion.getAccelY()).thenReturn((short) -78); // Negative raw value
 
             // Act
             double accelY = flightController.getAccelY();
 
             // Assert
-            assertEquals(-0.8, accelY, 0.01, "Acceleration should handle negative values");
+            assertEquals(-0.8, accelY, 0.02, "Acceleration should handle negative values");
         }
 
         @Test
@@ -297,13 +299,14 @@ public class SensorDataAccessTest {
         void testGetAccelZ() {
             // Arrange
             when(mockStatus.getMotion()).thenReturn(mockMotion);
-            when(mockMotion.getAccelZ()).thenReturn((short) 1000); // 1G
+            // raw for 1.0 G -> ~ 1.0 * 9.80665 / 0.1 = 98
+            when(mockMotion.getAccelZ()).thenReturn((short) 98); // Raw value corresponding to 1.0 G
 
             // Act
             double accelZ = flightController.getAccelZ();
 
             // Assert
-            assertEquals(1.0, accelZ, 0.01, "Z acceleration should represent gravity");
+            assertEquals(1.0, accelZ, 0.02, "Z acceleration should represent gravity");
         }
 
         @Test
@@ -311,13 +314,14 @@ public class SensorDataAccessTest {
         void testGetAngleX() {
             // Arrange
             when(mockStatus.getMotion()).thenReturn(mockMotion);
-            when(mockMotion.getAngleRoll()).thenReturn((short) 1500); // Raw value
+            // angles are raw degrees per reference
+            when(mockMotion.getAngleRoll()).thenReturn((short) 15); // 15 degrees raw
 
             // Act
             double angleX = flightController.getAngleX();
 
             // Assert
-            assertEquals(15.0, angleX, 0.01, "Angle should be scaled to degrees");
+            assertEquals(15.0, angleX, 0.01, "Angle should be in degrees");
         }
 
         @Test
@@ -325,7 +329,7 @@ public class SensorDataAccessTest {
         void testGetAngleY() {
             // Arrange
             when(mockStatus.getMotion()).thenReturn(mockMotion);
-            when(mockMotion.getAnglePitch()).thenReturn((short) -1000); // Negative
+            when(mockMotion.getAnglePitch()).thenReturn((short) -10); // -10 degrees raw
 
             // Act
             double angleY = flightController.getAngleY();
@@ -339,13 +343,13 @@ public class SensorDataAccessTest {
         void testGetAngleZ() {
             // Arrange
             when(mockStatus.getMotion()).thenReturn(mockMotion);
-            when(mockMotion.getAngleYaw()).thenReturn((short) 9000); // 90 degrees
+            when(mockMotion.getAngleYaw()).thenReturn((short) 90); // 90 degrees raw
 
             // Act
             double angleZ = flightController.getAngleZ();
 
             // Assert
-            assertEquals(90.0, angleZ, 0.01, "Yaw angle should be scaled correctly");
+            assertEquals(90.0, angleZ, 0.01, "Yaw angle should be degrees");
         }
 
         @Test


### PR DESCRIPTION
This draft PR centralizes sensor scaling and normalizes accelerometer/angle handling across the Java API.

Summary of changes
- Add `DroneSystem.SensorScales` constants and use them across the codebase.
- Fix endianness parsing in the receiver and add diagnostics.
- Update examples and GUI (`AccelTest`, `MotionDump`, `SensorDisplay`, `SensorDisplayGui`) to display scaled units (m/s^2 and g for acceleration; degrees for angles).
- Update `FlightController` getters and docs so the public API returns consistent, human-friendly units.
- Update unit tests (`SensorDataAccessTest`) to assert canonical scaling.
- Add README section documenting canonical sensor scaling.

Why
- Previous code used ad-hoc divisors (e.g., /100, /1000) leading to inconsistent and incorrect physical units in telemetry (discovered during testing).
- Centralizing conversion constants reduces future divergence and makes telemetry easier to reason about (essential for calibration and ML tasks).

Checklist (draft)
- [x] Centralize sensor scale constants in `DroneSystem.SensorScales`.
- [x] Update `FlightController` to use canonical scaling where appropriate (scaled getters and Javadoc).
- [x] Update examples and GUI to show human-friendly units.
- [x] Update unit tests to match canonical scaling.
- [x] Update README with sensor scaling documentation.
- [x] Run `./gradlew test` and ensure tests pass locally.
- [ ] Run interactive smoke test `./gradlew runAccelTest` against a physical controller to validate runtime values (requires hardware permission).
- [ ] Verify CI (if present) passes with the new branch.

Notes & follow-ups
- I intentionally left AP-CSA-compatible array-returning methods (`get_accel()`, `get_angle()`) returning raw protocol integers, but updated their Javadoc to describe raw units and point callers to the scaled getters.
- If you want, I can convert the array-returning methods to return scaled values instead — but that would be a breaking change for API parity.

If you'd like the PR description adjusted or want me to run the interactive smoke test, tell me and I'll proceed.
