### PR TITLE
docs: testing guide improvements + README run snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,11 @@ so the behavior stays consistent across the codebase.
 ## Changelog
 
 See `CHANGELOG.md` for a human-readable history of notable changes and merged PRs.
+
+## Running tests
+
+Run the unit test suite locally before connecting hardware. See `TESTING_GUIDE.md` for details.
+
+```bash
+./gradlew test
+```

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -126,6 +126,35 @@ This test file helps students verify their square flight pattern code **before**
 ./gradlew test --tests L0102FlightMovementsTest --info
 ```
 
+### Run tests locally (quick reference)
+
+The test suite is designed to run without hardware using the built-in `MockDrone`. Use these commands from the repository root:
+
+```bash
+# Run all tests (recommended before any hardware tests)
+./gradlew test
+
+# Run a single test class (full package path recommended)
+./gradlew test --tests com.otabi.jcodroneedu.examples.L0102FlightMovementsTest
+
+# Run with more logging
+./gradlew test --tests com.otabi.jcodroneedu.examples.L0102FlightMovementsTest --info
+```
+
+Notes:
+- If you add new drone API methods, update the `MockDrone` implementation in `src/test/java/com/otabi/jcodroneedu/DroneTest.java` so tests can simulate them.
+- Test helper classes and example tests live under `src/test/java/com/otabi/jcodroneedu/examples/`.
+
+### Extending MockDrone
+
+If you add new public API methods to `Drone` (for students to call), implement matching mock behavior in the nested `MockDrone` class in `DroneTest.java`:
+
+1. Add the method signature to `MockDrone` and record command history (see existing methods like `go(...)`, `square(...)`).
+2. Add any helper getters (e.g., `getUniquePitchValues()` or `getMethodCalls(String)`) used by tests.
+3. Run `./gradlew test` to verify tests exercise the new mock method.
+
+Link: See `PYTHON_MANAGEMENT.md` for a short checklist about updating MockDrone when adapting the Python reference.
+
 ### Understanding Test Results
 
 #### ✅ **Green (Passing) Tests**


### PR DESCRIPTION
Clarify where tests and example test classes live, add a 'run tests locally' quick reference, and document how to extend MockDrone when API methods change. Also add a short run-tests snippet to README.